### PR TITLE
Checking boundaries works. More testing and improve docs

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,20 +1,39 @@
+#![deny(missing_docs)]
 use snafu::Snafu;
 
-/// Error given when a formatter field is not resolved
-///
-/// Derives SNAFU to do error things
 #[derive(Debug, Snafu)]
-#[snafu(display("Format not recognized"), visibility(pub(crate)))]
-pub struct FormatDateError {}
-
-impl FormatDateError {
-    fn new() -> FormatDateError {
-        FormatDateError {}
-    }
-}
-
-impl Default for FormatDateError {
-    fn default() -> Self {
-        Self::new()
-    }
+/// Errors on date boundaries
+///
+/// The errors given when a date is out of bounds, for example a 13th month or the 41st day of a
+/// month.
+///
+/// Exmple:
+/// ```rust
+/// # use dates_str::DateStr;
+/// // TODO: Finish this example
+/// ```
+pub enum DateErrors {
+    /// Enum variant when day is out of bounds
+    #[snafu(
+        display("Day must be 0 <= day >= 30. It was {day}"),
+        visibility(pub(crate)),
+        context(suffix(Ctx))
+    )]
+    InvalidDay {
+        /// They "day" that provoked the error.
+        day: u8,
+    },
+    /// Enum variant when month is out of bounds
+    #[snafu(
+        display("Month must be 0 <= month >= 11. It was {month}"),
+        visibility(pub(crate)),
+        context(suffix(Ctx))
+    )]
+    InvalidMonth {
+        /// The "month" that provoked the error
+        month: u8,
+    },
+    /// Enum variant when a formatter field is not resolved
+    #[snafu(display("Format not recognized"), visibility(pub(crate)))]
+    FormatDateError,
 }

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -8,12 +8,20 @@ use crate::DateStr;
 pub trait ToDateStr {
     /// This function creates a DateStr in a to_string() fashion
     fn to_datestr(&self) -> DateStr;
+
+    /// Try to convert to DateStr using [DatesStr::try_from_iso_str] function, which returns a
+    /// Result enum.
+    fn try_to_datestr(&self) -> Result<DateStr, crate::errors::DateErrors>;
 }
 
 /// Implementation of ToDateStr for String
 impl ToDateStr for String {
     fn to_datestr(&self) -> DateStr {
         DateStr::from_iso_str(self)
+    }
+
+    fn try_to_datestr(&self) -> Result<DateStr, crate::errors::DateErrors> {
+        DateStr::try_from_iso_str(self)
     }
 }
 
@@ -22,11 +30,36 @@ impl ToDateStr for str {
     fn to_datestr(&self) -> DateStr {
         DateStr::from_iso_str(self)
     }
+
+    fn try_to_datestr(&self) -> Result<DateStr, crate::errors::DateErrors> {
+        DateStr::try_from_iso_str(self)
+    }
 }
 
 /// Implementation of ToDateStr for DateStr
 impl ToDateStr for DateStr {
     fn to_datestr(&self) -> DateStr {
         self.clone()
+    }
+
+    fn try_to_datestr(&self) -> Result<DateStr, crate::errors::DateErrors> {
+        DateStr::try_from_iso_str(self)
+    }
+}
+
+impl From<String> for DateStr {
+    fn from(value: String) -> Self {
+        let split: Vec<String> = value.split('-').map(|s| s.to_string()).collect();
+        DateStr {
+            year: split[0].parse::<u64>().unwrap_or(2020),
+            month: split[1].parse::<u8>().unwrap_or(0),
+            day: split[2].parse::<u8>().unwrap_or(0),
+        }
+    }
+}
+
+impl From<DateStr> for String {
+    fn from(value: DateStr) -> Self {
+        value.to_string()
     }
 }


### PR DESCRIPTION
Prevent from creating dates that are out of bounds, for example a date on month 55 or a 34th day, but still not checking for a 30th or 31st of february, wich would be out of bounds too.

Also improved documentation a bit, added more tests.

Added `From<String> for DateStr` and `From<DateStr> for String`, but not tested them yet.